### PR TITLE
Fixed typo in issuue #36

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -69,7 +69,7 @@ const Features = () => {
           </div>
           <div className="tracking-wide leading-7 w-full text-center md:text-left ">
             Our Chat Models allows you to generate responses to text inputs from
-            differnt LLMs. OpenAI, Gemini and Anthrotopic are supported for now.
+            different LLMs. OpenAI, Gemini and Anthropic are supported for now.
           </div>
           <Link
             href="/docs/components/chatOpenAi"


### PR DESCRIPTION
Fixed the typo mentioned in issue #36, which corrected the word ‘differnt’ to ‘different’ and 'anthrtopic' to 'anthropic' in 'features.tsx'