### PR TITLE
fix #43: default tab for linkedin should be playground tab

### DIFF
--- a/src/content/docs/components/linkedinAgent.mdx
+++ b/src/content/docs/components/linkedinAgent.mdx
@@ -3,7 +3,7 @@ title: LinkedIn Agent
 description: Use our exclusive linkedin agent to generate summary tables for public profiles.
 ---
 
-<Tabs defaultValue="preview">
+<Tabs defaultValue="playground">
 
 <TabsList>
   <TabsTrigger value="preview">Preview</TabsTrigger>


### PR DESCRIPTION
Default tab for linkedin agent is playground 