### PR TITLE
update sidebar w/o blog tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "mini-svg-data-uri": "^1.4.4",
         "moment": "^2.30.1",
         "mongoose": "^8.3.4",
-        "next": "14.2.3",
+        "next": "^14.2.3",
         "next-contentlayer": "^0.3.4",
         "next-mdx-remote": "^0.5.1",
         "next-themes": "^0.3.0",

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -70,18 +70,22 @@ export function CommandMenu({ ...props }: DialogProps) {
           <CommandGroup heading="Links">
             {docsConfig.mainNav
               .filter((navitem) => !navitem.external)
-              .map((navItem) => (
-                <CommandItem
-                  key={navItem.href}
-                  value={navItem.title}
-                  onSelect={() => {
-                    runCommand(() => router.push(navItem.href as string));
-                  }}
-                >
-                  <FileIcon className="mr-2 h-4 w-4" />
-                  {navItem.title}
-                </CommandItem>
-              ))}
+              .map((navItem) => {
+                console.log(navItem, navItem.title);
+
+                return (
+                  <CommandItem
+                    key={navItem.href}
+                    value={navItem.title}
+                    onSelect={() => {
+                      runCommand(() => router.push(navItem.href as string));
+                    }}
+                  >
+                    <FileIcon className="mr-2 h-4 w-4" />
+                    {navItem.title}
+                  </CommandItem>
+                );
+              })}
           </CommandGroup>
           {docsConfig.sidebarNav.map((group) => (
             <CommandGroup key={group.title} heading={group.title}>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -71,8 +71,6 @@ export function CommandMenu({ ...props }: DialogProps) {
             {docsConfig.mainNav
               .filter((navitem) => !navitem.external)
               .map((navItem) => {
-                console.log(navItem, navItem.title);
-
                 return (
                   <CommandItem
                     key={navItem.href}

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -11,19 +11,24 @@ export interface DocsSidebarNavProps {
 
 export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
   const pathname = usePathname();
+  // console.log(items,"start");
 
   return items.length ? (
     <div className="w-full">
-      {items.map((item, index) => (
-        <div key={index} className={cn('pb-4')}>
-          <h4 className="mb-1 rounded-md px-2 py-1 text-sm font-semibold">
-            {item.title}
-          </h4>
-          {item?.items?.length && (
-            <DocsSidebarNavItems items={item.items} pathname={pathname} />
-          )}
-        </div>
-      ))}
+      {items.map((item, index) =>
+        item.title !== 'Blog' ? (
+          <div key={index} className={cn('pb-4')}>
+            <h4 className="mb-1 rounded-md px-2 py-1 text-sm font-semibold">
+              {item.title}
+            </h4>
+            {item?.items?.length && (
+              <DocsSidebarNavItems items={item.items} pathname={pathname} />
+            )}
+          </div>
+        ) : (
+          ''
+        ),
+      )}
     </div>
   ) : null;
 }
@@ -37,6 +42,8 @@ export function DocsSidebarNavItems({
   items,
   pathname,
 }: DocsSidebarNavItemsProps) {
+  // console.log(items,pathname);
+
   return items?.length ? (
     <div className="grid grid-flow-row auto-rows-max text-sm">
       {items.map((item, index) =>

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -11,7 +11,6 @@ export interface DocsSidebarNavProps {
 
 export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
   const pathname = usePathname();
-  // console.log(items,"start");
 
   return items.length ? (
     <div className="w-full">
@@ -42,8 +41,6 @@ export function DocsSidebarNavItems({
   items,
   pathname,
 }: DocsSidebarNavItemsProps) {
-  // console.log(items,pathname);
-
   return items?.length ? (
     <div className="grid grid-flow-row auto-rows-max text-sm">
       {items.map((item, index) =>


### PR DESCRIPTION
closes #60 

The blog title won't be shown at the sidebar anymore.
You can still search for the blog and access the blogs the functionality is not impacted in any way.